### PR TITLE
ActionMailer::InlineCssHook.delivering_email trashes attachments

### DIFF
--- a/lib/action_mailer/inline_css_hook.rb
+++ b/lib/action_mailer/inline_css_hook.rb
@@ -1,33 +1,33 @@
+# encoding: utf-8
 #
 # Always inline CSS for HTML emails
 #
 module ActionMailer
   class InlineCssHook
     def self.delivering_email(message)
+
       if html_part = (message.html_part || (message.content_type =~ /text\/html/ && message))
+
         # Generate an email with all CSS inlined (access CSS a FS path)
-        premailer = ::Premailer.new(html_part.body.to_s,
-                                    :with_html_string => true)
+        premailer = ::Premailer.new(html_part.body.to_s, :with_html_string => true)
 
         # Prepend host to remaning URIs.
         # Two-phase conversion to avoid request deadlock from dev. server (Issue #4)
-        premailer = ::Premailer.new(premailer.to_inline_css,
-                                      :with_html_string => true,
-                                      :base_url => message.header[:host].to_s)
-        existing_text_part = message.text_part && message.text_part.body.to_s
-        # Reset the body
-        message.body = nil
+        premailer = ::Premailer.new(premailer.to_inline_css, :with_html_string => true,
+                                                             :base_url => message.header[:host].to_s)
+
         # Add an HTML part with CSS inlined.
         message.html_part do
           content_type "text/html; charset=utf-8"
           body premailer.to_inline_css
         end
-        # Add a text part with either the pre-existing text part, or one generated with premailer.
-        message.text_part do
-          content_type "text/plain; charset=utf-8"
-          body existing_text_part || premailer.to_plain_text
-        end
+
       end
+
+      # Return the message, ActionMailer doesn't seem to care, but it's useful
+      # for writing meaningful tests.
+      message
+
     end
   end
 end


### PR DESCRIPTION
The line `message.body = nil` trashes all message attachments, which is a problem!

I'd propose that in the same way that one maintain the `exiting_text_part`, one aught to preserve attachments too.

This also introduces the issue I raised in #8, which aught to be fixed separately, I think it may also break the untested code for "fallback the text segment to a text version of the HTML component", which was not important for my purposes.
