### PR TITLE
Set correct content type when attaching files

### DIFF
--- a/lib/action_mailer/inline_css_hook.rb
+++ b/lib/action_mailer/inline_css_hook.rb
@@ -34,6 +34,8 @@ module ActionMailer
             body premailer.to_inline_css
           end
 
+          message.content_type 'multipart/mixed' if ! existing_attachments.empty?
+
           existing_attachments.each {|a| message.body << a }
         end
 

--- a/test/inline_css_hook_test.rb
+++ b/test/inline_css_hook_test.rb
@@ -129,4 +129,15 @@ class InlineCssHookTest < ActionMailer::TestCase
     assert_equal original_hello_attachment_url, mail.attachments["hello"].url
   end
 
+  def test_alternative_content_type
+    mail = HelperMailer.use_inline_css_hook_with_text_and_html_parts.deliver
+    assert_match /multipart\/alternative/, mail.content_type
+  end
+
+  def test_mixed_content_type
+    File.stubs(:read).returns("world")
+    mail = HelperMailer.with_attachment
+    m = ActionMailer::InlineCssHook.delivering_email(mail.deliver)
+    assert_equal "multipart/mixed", m.content_type
+  end
 end


### PR DESCRIPTION
When files are attached the content type gets reset back to multipart/alternative. It should  be multipart/mixed. This causes only the attachment to be displayed on certain email clients like the iPhone.
