### PR TITLE
Eliminate Rails 5 deprecation warning.

### DIFF
--- a/lib/overrides/premailer/premailer.rb
+++ b/lib/overrides/premailer/premailer.rb
@@ -1,11 +1,11 @@
 require 'premailer'
 
-Premailer.class_eval do
+module LoadFileWithRailsPath
   protected
   # When using the 'stylesheet_link_tag' helper in Rails, css URIs are given with
   # a leading slash and a cache buster (e.g. ?12412422).
   # This override handles these cases, while falling back to the default implementation.
-  def load_css_from_local_file_with_rails_path!(path)
+  def load_css_from_local_file!(path)
     # Remove query string and the path
     clean_path = path.sub(/\?.*$/, '').sub(%r(^https?://[^/]*/), '')
     rails_path = Rails.root.join('public', clean_path)
@@ -14,10 +14,12 @@ Premailer.class_eval do
     elsif (asset = Rails.application.assets.find_asset(clean_path.sub("#{Rails.configuration.assets.prefix}/", '')))
       load_css_from_string(asset.source)
     else
-      load_css_from_local_file_without_rails_path!(path)
+      super(path)
     end
   end
-  alias_method_chain :load_css_from_local_file!, :rails_path
+end
 
+class Premailer
+  prepend LoadFileWithRailsPath
 end
 


### PR DESCRIPTION
Replaced `alias_method_chain` with Module.prepend